### PR TITLE
move build* functions out of inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ jspm_packages
 .vscode
 build
 docs
+benchmark-out

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,0 +1,37 @@
+import * as Benchmark from 'benchmark';
+import * as _ from 'lodash';
+import {
+  quality,
+  quality_1vs1,
+  rate,
+  rate_1vs1,
+  Rating,
+  setup,
+  TrueSkill,
+  winProbability,
+} from '../build/index';
+
+function generateTeams(sizes: number[], env?: TrueSkill) {
+  return sizes.map((size) => {
+    const r = _.fill(Array(size), 0);
+    if (env) {
+      return r.map(() => env.createRating());
+    }
+    return r.map(() => new Rating());
+  });
+}
+
+function generateIndividual(size: number) {
+  return generateTeams(_.fill(Array(size), 1));
+}
+
+const suite = new Benchmark.Suite();
+suite
+  .add('5 vs 5', () => {
+    const [team1, team2] = generateTeams([5, 5]);
+    const rated = rate([team1, team2]);
+  })
+  .on('cycle', (event: any) => {
+    console.log(String(event.target));
+  })
+  .run({ async: true });

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../benchmark-out",
+    "baseUrl": ""
+  },
+  "include": ["./*"]
+}

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "clean": "rimraf build coverage docs benchmark-out .nyc_output",
     "build": "npm run clean; tsc -p .",
     "build:watch": "tsc -p . -w",
-    "test": "mocha --require ./test/tshook.js test/*.spec.ts",
+    "test": "mocha --require test/tshook.js test/*.spec.ts",
     "coverage": "nyc npm test",
     "docs": "typedoc --gitRevision master --out docs --exclude \"**/*+(spec).ts\"; touch docs/.nojekyll",
     "lint": "tslint \"src/**/*.ts\"",
-    "benchmark": "npm run build; tsc -p benchmark; node --inspect --debug-brk benchmark-out"
+    "benchmark": "npm run build; tsc -p benchmark; node benchmark-out"
   },
   "dependencies": {
     "gaussian": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run clean; tsc -p .",
     "build:watch": "tsc -p . -w",
     "test": "mocha --require test/tshook.js test/*.spec.ts",
-    "coverage": "nyc npm test",
+    "coverage": "nyc npm run test",
     "docs": "typedoc --gitRevision master --out docs --exclude \"**/*+(spec).ts\"; touch docs/.nojekyll",
     "lint": "tslint \"src/**/*.ts\"",
     "benchmark": "npm run build; tsc -p benchmark; node benchmark-out"
@@ -45,7 +45,7 @@
     "sourceMap": true,
     "instrument": true,
     "require": [
-      "ts-node/register"
+      "./test/tshook.js"
     ],
     "include": [
       "src/**/*.ts"

--- a/package.json
+++ b/package.json
@@ -2,18 +2,20 @@
   "name": "ts-trueskill",
   "version": "1.2.0",
   "description": "Port of python trueskill package in TypeScript",
-  "main": "src/index.js",
-  "typings": "src/index.d.ts",
+  "main": "./index.js",
+  "typings": "./index.d.ts",
   "repository": "https://github.com/scttcper/ts-trueskill.git",
   "author": "Scott Cooper <scttcper@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "build": "tsc -p .",
+    "clean": "rimraf build coverage docs benchmark-out .nyc_output",
+    "build": "npm run clean; tsc -p .",
     "build:watch": "tsc -p . -w",
-    "test": "mocha --require ts-node/register test/*.spec.ts",
+    "test": "mocha --require ./test/tshook.js test/*.spec.ts",
     "coverage": "nyc npm test",
     "docs": "typedoc --gitRevision master --out docs --exclude \"**/*+(spec).ts\"; touch docs/.nojekyll",
-    "lint": "tslint \"src/**/*.ts\""
+    "lint": "tslint \"src/**/*.ts\"",
+    "benchmark": "npm run build; tsc -p benchmark; node --inspect --debug-brk benchmark-out"
   },
   "dependencies": {
     "gaussian": "^1.1.0",
@@ -22,6 +24,7 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
+    "@types/benchmark": "^1.0.30",
     "@types/chai": "^3.5.2",
     "@types/gaussian": "^1.1.1",
     "@types/lodash": "^4.14.64",
@@ -29,6 +32,7 @@
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.18",
     "@types/uuid": "^2.0.29",
+    "benchmark": "^2.1.4",
     "chai": "^3.5.0",
     "mocha": "^3.4.1",
     "nyc": "^10.3.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -478,7 +478,6 @@ export class TrueSkill {
     if (minDelta <= 0) {
       throw new Error('minDelta must be greater than 0');
     }
-    const layers = [];
     const ratingLayer: PriorFactor[] = this.buildRatingLayer(ratingVars, flattenRatings);
     const perfLayer: LikelihoodFactor[] = this.buildPerfLayer(ratingVars, perfVars);
     const teamPerfLayer: SumFactor[] = this.buildTeamPerfLayer(
@@ -487,14 +486,12 @@ export class TrueSkill {
       teamSizes,
       flattenWeights,
     );
-    layers.push(ratingLayer, perfLayer, teamPerfLayer);
     ratingLayer.map((f) => f.down());
     perfLayer.map((f) => f.down());
     teamPerfLayer.map((f) => f.down());
     // arrow #1, #2, #3
     const teamDiffLayer: SumFactor[] = this.buildTeamDiffLayer(teamPerfVars, teamDiffVars);
     const truncLayer: TruncateFactor[] = this.buildTruncLayer(teamDiffVars, sortedRanks, sortedRatingGroups);
-    layers.push(teamDiffLayer, truncLayer);
     const teamDiffLen = teamDiffLayer.length;
     for (let index = 0; index <= 10; index++) {
       let delta = 0;
@@ -527,7 +524,7 @@ export class TrueSkill {
     // up the remainder of the black arrows
     teamPerfLayer.map((f) => _.range(f.vars.length - 1).map((x) => f.up(x)));
     perfLayer.map((f) => f.up());
-    return layers;
+    return [ratingLayer, perfLayer, teamPerfLayer, teamDiffLayer, truncLayer];
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,9 +43,7 @@ export function calcDrawMargin(drawProbability: number, size: number, env?: True
  */
 function _teamSizes(ratingGroups: Rating[][]) {
   const teamSizes = [0];
-  for (const group of ratingGroups) {
-    teamSizes.push(group.length + teamSizes[teamSizes.length - 1]);
-  }
+  ratingGroups.map((group) => teamSizes.push(group.length + teamSizes[teamSizes.length - 1]));
   teamSizes.shift();
   return teamSizes;
 }
@@ -143,9 +141,7 @@ export class TrueSkill {
       position++;
       return res;
     });
-    const sorting = _.orderBy(positions, (x) => {
-      return x[1][1];
-    });
+    const sorting = _.orderBy(positions, (x) => x[1][1]);
     const sortedRatingGroups: Rating[][] = [];
     const sortedRanks: number[] = [];
     const sortedWeights: number[][] = [];
@@ -167,77 +163,28 @@ export class TrueSkill {
     const teamDiffVars: Variable[] = _.range(groupSize - 1).map(() => new Variable());
     const teamSizes = _teamSizes(sortedRatingGroups);
     // layer builders
-    const buildRatingLayer = () => {
-      const pf: PriorFactor[] = [];
-      for (let idx = 0; idx < ratingVars.length; idx++) {
-        pf.push(new PriorFactor(ratingVars[idx], flattenRatings[idx], this.tau));
-      }
-      return pf;
-    };
-    const buildPerfLayer = () => {
-      const lf: LikelihoodFactor[] = [];
-      for (let idx = 0; idx < ratingVars.length; idx++) {
-        lf.push(new LikelihoodFactor(ratingVars[idx], perfVars[idx], this.beta ** 2));
-      }
-      return lf;
-    };
-    const buildTeamPerfLayer = () => {
-      let team = 0;
-      return teamPerfVars.map((teamPerfVar) => {
-        const start = team > 0 ? teamSizes[team - 1] : 0;
-        const end = teamSizes[team];
-        team++;
-        const childPerfVars = perfVars.slice(start, end);
-        const coeffs = flattenWeights.slice(start, end);
-        return new SumFactor(teamPerfVar, childPerfVars, coeffs);
-      });
-    };
-    const buildTeamDiffLayer = () => {
-      let team = 0;
-      return teamDiffVars.map((teamDiffVar) => {
-        const sl = teamPerfVars.slice(team, team + 2);
-        team++;
-        return new SumFactor(teamDiffVar, sl, [1, -1]);
-      });
-    };
-    const buildTruncLayer = () => {
-      let x = 0;
-      return teamDiffVars.map((teamDiffVar) => {
-        // static draw probability
-        const drawProbability = this.drawProbability;
-        const lengths = sortedRatingGroups.slice(x, x + 2).map((n) => n.length);
-        const drawMargin = calcDrawMargin(drawProbability, _.sum(lengths), this);
-        let vFunc;
-        let wFunc;
-        if (sortedRanks[x] === sortedRanks[x + 1]) {
-          vFunc = (a: number, b: number) => this.v_draw(a, b);
-          wFunc = (a: number, b: number) => this.w_draw(a, b);
-        } else {
-          vFunc = (a: number, b: number) => this.v_win(a, b);
-          wFunc = (a: number, b: number) => this.w_win(a, b);
-        }
-        x++;
-        return new TruncateFactor(teamDiffVar, vFunc, wFunc, drawMargin);
-      });
-    };
     const layers = this.runSchedule(
-      buildRatingLayer,
-      buildPerfLayer,
-      buildTeamPerfLayer,
-      buildTeamDiffLayer,
-      buildTruncLayer,
+      ratingVars,
+      flattenRatings,
+      perfVars,
+      teamPerfVars,
+      teamSizes,
+      flattenWeights,
+      teamDiffVars,
+      sortedRanks,
+      sortedRatingGroups,
       minDelta,
     );
     const ratingLayer: any[] = layers[0];
     const transformedGroups: Rating[][] = [];
     const trimmed = teamSizes.slice(0, teamSizes.length - 1);
-    for (const [start, end] of _.zip([0].concat(trimmed), teamSizes)) {
+    _.zip([0].concat(trimmed), teamSizes).map(([start, end]) => {
       const group: Rating[] = [];
       ratingLayer.slice(start, end).map((f: PriorFactor) => {
         group.push(new Rating(f.v.mu, f.v.sigma));
       });
       transformedGroups.push(group);
-    }
+    });
     const pulled = sorting.map(([x, zz]) => x);
     const pulledTranformedGroups: Array<[number, Rating[]]> = [];
     for (let idx = 0; idx < pulled.length; idx++) {
@@ -453,38 +400,104 @@ export class TrueSkill {
     return weights;
   }
 
+  private buildRatingLayer(ratingVars: Variable[], flattenRatings: Rating[]) {
+    const pf: PriorFactor[] = [];
+    for (let idx = 0; idx < ratingVars.length; idx++) {
+      pf.push(new PriorFactor(ratingVars[idx], flattenRatings[idx], this.tau));
+    }
+    return pf;
+  }
+
+  private buildPerfLayer(ratingVars: Variable[], perfVars: Variable[]) {
+    const lf: LikelihoodFactor[] = [];
+    for (let idx = 0; idx < ratingVars.length; idx++) {
+      lf.push(new LikelihoodFactor(ratingVars[idx], perfVars[idx], this.beta ** 2));
+    }
+    return lf;
+  }
+  private buildTeamPerfLayer(
+    teamPerfVars: Variable[],
+    perfVars: Variable[],
+    teamSizes: number[],
+    flattenWeights: number[],
+   ) {
+    let team = 0;
+    return teamPerfVars.map((teamPerfVar) => {
+      const start = team > 0 ? teamSizes[team - 1] : 0;
+      const end = teamSizes[team];
+      team = team + 1;
+      return new SumFactor(
+        teamPerfVar,
+        perfVars.slice(start, end),
+        flattenWeights.slice(start, end),
+      );
+    });
+  }
+  private buildTeamDiffLayer(teamPerfVars: Variable[], teamDiffVars: Variable[]) {
+    let team = 0;
+    return teamDiffVars.map((teamDiffVar) => {
+      const sl = teamPerfVars.slice(team, team + 2);
+      team++;
+      return new SumFactor(teamDiffVar, sl, [1, -1]);
+    });
+  }
+  private buildTruncLayer(teamDiffVars: Variable[], sortedRanks: number[], sortedRatingGroups: Rating[][]) {
+    let x = 0;
+    return teamDiffVars.map((teamDiffVar) => {
+      // static draw probability
+      const drawProbability = this.drawProbability;
+      const lengths = sortedRatingGroups.slice(x, x + 2).map((n) => n.length);
+      const drawMargin = calcDrawMargin(drawProbability, _.sum(lengths), this);
+      let vFunc = (a: number, b: number) => this.v_win(a, b);
+      let wFunc = (a: number, b: number) => this.w_win(a, b);
+      if (sortedRanks[x] === sortedRanks[x + 1]) {
+        vFunc = (a: number, b: number) => this.v_draw(a, b);
+        wFunc = (a: number, b: number) => this.w_draw(a, b);
+      }
+      x++;
+      return new TruncateFactor(teamDiffVar, vFunc, wFunc, drawMargin);
+    });
+  }
+
   /**
    * Sends messages within every nodes of the factor graph
    * until the result is reliable.
    */
   private runSchedule(
-    buildRatingLayer: () => PriorFactor[],
-    buildPerfLayer: () => LikelihoodFactor[],
-    buildTeamPerfLayer: () => SumFactor[],
-    buildTeamDiffLayer: () => SumFactor[],
-    buildTruncLayer: () => TruncateFactor[],
+    ratingVars: Variable[],
+    flattenRatings: Rating[],
+    perfVars: Variable[],
+    teamPerfVars: Variable[],
+    teamSizes: number[],
+    flattenWeights: number[],
+    teamDiffVars: Variable[],
+    sortedRanks: number[],
+    sortedRatingGroups: Rating[][],
     minDelta = DELTA,
   ) {
     if (minDelta <= 0) {
       throw new Error('minDelta must be greater than 0');
     }
     const layers = [];
-    const ratingLayer: PriorFactor[] = buildRatingLayer();
-    const perfLayer: LikelihoodFactor[] = buildPerfLayer();
-    const teamPerfLayer: SumFactor[] = buildTeamPerfLayer();
+    const ratingLayer: PriorFactor[] = this.buildRatingLayer(ratingVars, flattenRatings);
+    const perfLayer: LikelihoodFactor[] = this.buildPerfLayer(ratingVars, perfVars);
+    const teamPerfLayer: SumFactor[] = this.buildTeamPerfLayer(
+      teamPerfVars,
+      perfVars,
+      teamSizes,
+      flattenWeights,
+    );
     layers.push(ratingLayer, perfLayer, teamPerfLayer);
-    for (const layer of [ratingLayer, perfLayer, teamPerfLayer]) {
-      for (const f of layer) {
-        f.down();
-      }
-    }
+    ratingLayer.map((f) => f.down());
+    perfLayer.map((f) => f.down());
+    teamPerfLayer.map((f) => f.down());
     // arrow #1, #2, #3
-    const teamDiffLayer: SumFactor[] = buildTeamDiffLayer();
-    const truncLayer: TruncateFactor[] = buildTruncLayer();
+    const teamDiffLayer: SumFactor[] = this.buildTeamDiffLayer(teamPerfVars, teamDiffVars);
+    const truncLayer: TruncateFactor[] = this.buildTruncLayer(teamDiffVars, sortedRanks, sortedRatingGroups);
     layers.push(teamDiffLayer, truncLayer);
     const teamDiffLen = teamDiffLayer.length;
     for (let index = 0; index <= 10; index++) {
-      let delta;
+      let delta = 0;
       if (teamDiffLen === 1) {
         // only two teams
         teamDiffLayer[0].down();
@@ -492,16 +505,16 @@ export class TrueSkill {
       } else {
         // multiple teams
         delta = 0;
-        for (const z of _.range(teamDiffLen - 1)) {
+        _.range(teamDiffLen - 1).map((z) => {
           teamDiffLayer[z].down();
           delta = Math.max(delta, truncLayer[z].up());
           teamDiffLayer[z].up(1);
-        }
-        for (const z of _.range(teamDiffLen - 1, 0, -1)) {
+        });
+        _.range(teamDiffLen - 1, 0, -1).map((z) => {
           teamDiffLayer[z].down();
           delta = Math.max(delta, truncLayer[z].up());
           teamDiffLayer[z].up(0);
-        }
+        });
       }
       // repeat until too small update
       if (delta <= minDelta) {
@@ -512,14 +525,8 @@ export class TrueSkill {
     teamDiffLayer[0].up(0);
     teamDiffLayer[teamDiffLen - 1].up(1);
     // up the remainder of the black arrows
-    for (const f of teamPerfLayer) {
-      for (const x of _.range(f.vars.length - 1)) {
-        f.up(x);
-      }
-    }
-    for (const f of perfLayer) {
-      f.up();
-    }
+    teamPerfLayer.map((f) => _.range(f.vars.length - 1).map((x) => f.up(x)));
+    perfLayer.map((f) => f.up());
     return layers;
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -15,7 +15,7 @@ import { Gaussian } from '../src/mathematics';
 
 function generateTeams(sizes: number[], env?: TrueSkill) {
   return sizes.map((size) => {
-    const r = new Array(size).fill(0);
+    const r = _.fill(Array(size), 0);
     if (env) {
       return r.map(() => env.createRating());
     }
@@ -24,7 +24,7 @@ function generateTeams(sizes: number[], env?: TrueSkill) {
 }
 
 function generateIndividual(size: number) {
-  return generateTeams(Array(size).fill(1));
+  return generateTeams(_.fill(Array(size), 1));
 }
 
 function compareRating(result: Rating[][], expected: number[][]) {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,5 +4,5 @@
     "types" : ["node", "mocha"],
     "baseUrl": ""
   },
-  "include": ["./*"]
+  "include": ["*"]
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types" : ["node", "mocha"],
+    "baseUrl": ""
+  },
+  "include": ["./*"]
+}

--- a/test/tshook.js
+++ b/test/tshook.js
@@ -1,0 +1,3 @@
+require('ts-node').register({
+  project: './test/tsconfig.json',
+})

--- a/test/tshook.js
+++ b/test/tshook.js
@@ -1,3 +1,3 @@
 require('ts-node').register({
-  project: './test/tsconfig.json',
+  project: 'test/tsconfig.json',
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,9 @@
     "module": "commonjs",
     "outDir": "build",
     "strict": true,
-    "types" : ["mocha"]
+    "types" : ["node"]
   },
   "include": [
-    "src/**/*",
-    "test/**/*"
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
no changes
5 vs 5 x 2,592 ops/sec ±2.51% (83 runs sampled)

after uuid v1 and moving buildPerfLayers out 
5 vs 5 x 3,595 ops/sec ±2.32% (81 runs sampled)

after removing some of the for..of in runSchedule
5 vs 5 x 3,645 ops/sec ±2.70% (84 runs sampled)