### PR TITLE
fix: expose method formula

### DIFF
--- a/src/trueskill.ts
+++ b/src/trueskill.ts
@@ -260,7 +260,7 @@ export class TrueSkill {
    */
   expose(rating: Rating): number {
     const k = this.mu / this.sigma;
-    return (rating.mu - k) * rating.sigma;
+    return rating.mu - (k * rating.sigma);
   }
 
   /**


### PR DESCRIPTION
Fix leaderboard rating formula in TrueSkill.expose() method.
closes #203