### PR TITLE
fix: Error in win probability calculation

### DIFF
--- a/src/trueskill.ts
+++ b/src/trueskill.ts
@@ -246,7 +246,7 @@ export class TrueSkill {
     const sumSigma =
       a.reduce((t, n) => n.sigma ** 2 + t, 0) + b.reduce((t, n) => n.sigma ** 2 + t, 0);
     const playerCount = a.length + b.length;
-    const denominator = Math.sqrt(playerCount * (this.beta * this.beta + sumSigma));
+    const denominator = Math.sqrt(playerCount * this.beta * this.beta + sumSigma);
     return this.guassian.cdf(deltaMu / denominator);
   }
 


### PR DESCRIPTION
Hi, I think I found a mistake in the win probability calculation function.

When comparing the function to https://github.com/sublee/trueskill/issues/1 or the original comment on http://www.moserware.com/2010/03/computing-your-skill.html, I found that the order of operations is different from how it is written in this library.